### PR TITLE
Update spec of new Record ID for backward compatibility

### DIFF
--- a/features/126-record-id/implementation.md
+++ b/features/126-record-id/implementation.md
@@ -59,8 +59,16 @@
 // New
 {
     "action": "record:delete",
-    "ids": ["4d4a6018-d365-4103-b35a-249b972ae614"]
-    "type": "note"
+    "recordIDs": ["4d4a6018-d365-4103-b35a-249b972ae614"]
+    "recordType": "note"
+}
+
+// Transitional (maintaining backward compatibility)
+{
+    "action": "record:delete",
+    "ids": ["note/4d4a6018-d365-4103-b35a-249b972ae614"],
+    "recordIDs": ["4d4a6018-d365-4103-b35a-249b972ae614"],
+    "recordType": "note"
 }
 ```
 


### PR DESCRIPTION
This commit is to update the spec of `record:delete`
action using new Record ID format for backward compatibility.

refs #126