### PR TITLE
[API Consistency] Update fetch, non-atomic save and delete api

### DIFF
--- a/features/207-sdk-api-consistency/record-api.md
+++ b/features/207-sdk-api-consistency/record-api.md
@@ -32,23 +32,29 @@ https://github.com/SkygearIO/features/pull/227 is considered in this doc.
 
 ```objc
 - (void)performQuery:(SKYQuery *)query
-    completionHandler:
-        (void (^_Nullable)(NSArray *_Nullable results, NSError *_Nullable error))completionHandler;
+          completion:
+            (void (^_Nullable)(NSArray *_Nullable results, NSError *_Nullable error))completion;
 
 - (void)performCachedQuery:(SKYQuery *)query
-         completionHandler:(void (^_Nullable)(NSArray *_Nullable results, BOOL pending,
-                                              NSError *_Nullable error))completionHandler;
+                completion:(void (^_Nullable)(NSArray *_Nullable results, BOOL pending,
+                                              NSError *_Nullable error))completion;
 
 - (void)fetchRecordWithType:(NSString *)recordType
                    recordID:(NSString *)recordID
-          completionHandler:(void (^)(SKYRecord *record, NSError *error))completionHandler;
+                 completion:(void (^_Nullable)(SKYRecord *_Nullable record,
+                                               NSError *_Nullable error))completion;
+
+@interface SKYFetchResult
+
+@property (nonatomic, readonly) SKYRecord *_Nullable record;
+@property (nonatomic, readonly) NSError *_Nullable error;
+
+@end
 
 - (void)fetchRecordsWithType:(NSString *)recordType
                    recordIDs:(NSArray<NSString *> *)recordIDs
-           completionHandler:(void (^)(NSDictionary<NSString *, SKYRecord *> *recordsByRecordID,
-                                      NSError *operationError))completionHandler
-      perRecordErrorHandler:(void (^)(NSString *recordID,
-                                      NSError *error))errorHandler;
+                  completion:(void (^)(NSArray<SKYFetchResult*> *results,
+                                       NSError *operationError))completion;
 ```
 
 #### Android
@@ -191,13 +197,20 @@ typedef void (^SKYRecordSaveCompletion)(SKYRecord *record, NSError *error);
         completion:(SKYRecordSaveCompletion)completion;
 
 - (void)saveRecords:(NSArray<SKYRecord *> *)records
-        completionHandler:(void (^)(NSArray *savedRecords,
-                                    NSError *operationError))completionHandler;
+         completion:(void (^)(NSArray *savedRecords,
+                              NSError *operationError))completion;
+
+
+@interface SKYNonAtomicSaveResult
+
+@property (nonatomic, readonly) SKYRecord *_Nullable record;
+@property (nonatomic, readonly) NSError *_Nullable error;
+
+@end
 
 - (void)saveRecordsNonAtomically:(NSArray<SKYRecord *> *)records
-               completionHandler:(void (^)(NSArray *savedRecords,
-                                           NSError *operationError))completionHandler
-           perRecordErrorHandler:(void (^)(SKYRecord * record, NSError * error))errorHandler;
+                      completion:(void (^)(NSArray<SKYNonAtomicSaveResult*> *results,
+                                           NSError *operationError))completion;
 ```
 
 #### Android
@@ -300,22 +313,26 @@ saveNonAtomically(records: Record[]): Promise<NonAtomicSaveResult[]>;
 ```objc
 - (void)deleteRecordWithType:(NSString *)recordType
                     recordID:(NSString *)recordID
-           completionHandler:(void (^_Nullable)(NSString *_Nullable recordID,
-                                                NSError *_Nullable error))completionHandler;
+                  completion:(void (^_Nullable)(NSString *_Nullable recordID,
+                                                NSError *_Nullable error))completion;
 
 - (void)deleteRecordsWithType:(NSString *)recordType
                     recordIDs:(NSArray<NSString *> *)recordIDs
-           completionHandler:(void (^_Nullable)(NSArray *_Nullable deletedRecordIDs,
-                                                NSError *_Nullable error))completionHandler;
+                   completion:(void (^_Nullable)(NSArray *_Nullable deletedRecordIDs,
+                                                 NSError *_Nullable error))completion;
+
+@interface SKYNonAtomicDeleteResult
+
+@property (nonatomic, readonly) String *_Nullable recordID;
+@property (nonatomic, readonly) NSError *_Nullable error;
+
+@end
 
 - (void)deleteRecordsWithTypeNonAtomically:(NSString *)recordType
                                  recordIDs:(NSArray<NSString *> *)recordIDs
-                         completionHandler:
-                            (void (^_Nullable)(NSArray *_Nullable deletedRecordIDs,
-                                               NSError *_Nullable error))completionHandler
-                     perRecordErrorHandler:
-                         (void (^_Nullable)(NSString *_Nullable recordID,
-                                             NSError *_Nullable error))errorHandler;
+                                completion:
+                            (void (^_Nullable)(NSArray<SKYNonAtomicDeleteResult*> *_Nullable results,
+                                               NSError *_Nullable error))completion;
 ```
 
 #### Android

--- a/features/207-sdk-api-consistency/record-api.md
+++ b/features/207-sdk-api-consistency/record-api.md
@@ -54,7 +54,21 @@ https://github.com/SkygearIO/features/pull/227 is considered in this doc.
 - (void)fetchRecordsWithType:(NSString *)recordType
                    recordIDs:(NSArray<NSString *> *)recordIDs
                   completion:(void (^)(NSArray<SKYFetchResult*> *results,
-                                       NSError *operationError))completion;
+                                       NSError *operationError))completion NS_REFINED_FOR_SWIFT;
+```
+
+```swift
+enum RecordResult<T> {
+    case success(T)
+    case error(NSError)
+}
+
+extension SKYDatabase {
+    func fetchRecords(type: NSString,
+                      recordIDs: [NSString],
+                      completion: ([RecordResult<SKYRecord>]?, NSError?) -> Void) {
+    }
+}
 ```
 
 #### Android
@@ -226,7 +240,21 @@ typedef void (^SKYRecordSaveCompletion)(SKYRecord *record, NSError *error);
 
 - (void)saveRecordsNonAtomically:(NSArray<SKYRecord *> *)records
                       completion:(void (^)(NSArray<SKYNonAtomicSaveResult*> *results,
-                                           NSError *operationError))completion;
+                                           NSError *operationError))completion NS_REFINED_FOR_SWIFT;
+```
+
+```swift
+enum RecordResult<T> {
+    case success(T)
+    case error(NSError)
+}
+
+extension SKYDatabase {
+    func saveRecordsNonAtomically(type: NSString,
+                                  records: [SKYRecord],
+                                  completion: ([RecordResult<SKYRecord>]?, NSError?) -> Void) {
+    }
+}
 ```
 
 #### Android
@@ -346,7 +374,21 @@ saveNonAtomically(records: Record[]): Promise<NonAtomicSaveResult[]>;
                                  recordIDs:(NSArray<NSString *> *)recordIDs
                                 completion:
                             (void (^_Nullable)(NSArray<SKYNonAtomicDeleteResult*> *_Nullable results,
-                                               NSError *_Nullable error))completion;
+                                               NSError *_Nullable error))completion NS_NS_REFINED_FOR_SWIFT;
+```
+
+```swift
+enum RecordResult<T> {
+    case success(T)
+    case error(NSError)
+}
+
+extension SKYDatabase {
+    func deleteRecordsNonAtomically(type: NSString,
+                                    recordIDs: [NSString],
+                                    completion: ([RecordResult<NSString>]?, NSError?) -> Void) {
+    }
+}
 ```
 
 #### Android

--- a/features/207-sdk-api-consistency/record-api.md
+++ b/features/207-sdk-api-consistency/record-api.md
@@ -45,6 +45,7 @@ https://github.com/SkygearIO/features/pull/227 is considered in this doc.
                                                NSError *_Nullable error))completion;
 
 // Generic RecordResult object for fetch, non-atomic save and delete
+NS_SWIFT_NAME("__SKYRecordResult")
 @interface SKYRecordResult<ObjectType> : NSObject
 
 @property (nonatomic, readonly) ObjectType value;
@@ -59,7 +60,7 @@ https://github.com/SkygearIO/features/pull/227 is considered in this doc.
 ```
 
 ```swift
-enum RecordResult<T> {
+enum SKYRecordResult<T> {
     case success(T)
     case error(NSError)
 }
@@ -67,7 +68,7 @@ enum RecordResult<T> {
 extension SKYDatabase {
     func fetchRecords(type: NSString,
                       recordIDs: [NSString],
-                      completion: ([RecordResult<SKYRecord>]?, NSError?) -> Void) {
+                      completion: ([SKYRecordResult<SKYRecord>]?, NSError?) -> Void) {
     }
 }
 ```
@@ -232,6 +233,7 @@ typedef void (^SKYRecordSaveCompletion)(SKYRecord *record, NSError *error);
                               NSError *operationError))completion;
 
 // Generic RecordResult object for fetch, non-atomic save and delete
+NS_SWIFT_NAME("__SKYRecordResult")
 @interface SKYRecordResult<ObjectType> : NSObject
 
 @property (nonatomic, readonly) ObjectType value;
@@ -245,7 +247,7 @@ typedef void (^SKYRecordSaveCompletion)(SKYRecord *record, NSError *error);
 ```
 
 ```swift
-enum RecordResult<T> {
+enum SKYRecordResult<T> {
     case success(T)
     case error(NSError)
 }
@@ -253,7 +255,7 @@ enum RecordResult<T> {
 extension SKYDatabase {
     func saveRecordsNonAtomically(type: NSString,
                                   records: [SKYRecord],
-                                  completion: ([RecordResult<SKYRecord>]?, NSError?) -> Void) {
+                                  completion: ([SKYRecordResult<SKYRecord>]?, NSError?) -> Void) {
     }
 }
 ```
@@ -376,12 +378,14 @@ saveNonAtomically(records: Record[]): Promise<NonAtomicSaveResult[]>;
                                          NSError *_Nullable error))completion;
 
 // Generic RecordResult object for fetch, non-atomic save and delete
+NS_SWIFT_NAME("__SKYRecordResult")
 @interface SKYRecordResult<ObjectType> : NSObject
 
 @property (nonatomic, readonly) ObjectType value;
 @property (nonatomic, readonly) NSError* error;
 
 @end
+
 // results contain deleted record id
 - (void)deleteRecordsWithTypeNonAtomically:(NSString *)recordType
                                  recordIDs:(NSArray<NSString *> *)recordIDs
@@ -404,11 +408,11 @@ enum SKYRecordResult<T> {
 extension SKYDatabase {
     func deleteRecordsNonAtomically(type: NSString,
                                     recordIDs: [NSString],
-                                    completion: ([RecordResult<NSString>]?, NSError?) -> Void) {
+                                    completion: ([SKYRecordResult<NSString>]?, NSError?) -> Void) {
     }
 
     func deleteRecordsNonAtomically(records: [SKYRecords],
-                                    completion: ([RecordResult<SKYRecord>]?, NSError?) -> Void) {
+                                    completion: ([SKYRecordResult<SKYRecord>]?, NSError?) -> Void) {
     }
 }
 ```
@@ -488,8 +492,8 @@ del(records: Record | Record[] | QueryResult): Promise<DeleteResult | DeleteResu
 
 ##### New
 
-- Deleted record is an `Record` Object that contain `_recordID`, `_recordType` and `deleted`,
-`deleted` is `true` and the other part of record is empty.
+- Deleted record is an `Record` Object that contain `_recordID`, `_recordType` and `_deleted`,
+`_deleted` is `true` and the other part of record is empty.
 
 ```ts
 deleteRecordByID(type: string, id: string): Promise<String>;

--- a/features/207-sdk-api-consistency/record-api.md
+++ b/features/207-sdk-api-consistency/record-api.md
@@ -44,16 +44,17 @@ https://github.com/SkygearIO/features/pull/227 is considered in this doc.
                  completion:(void (^_Nullable)(SKYRecord *_Nullable record,
                                                NSError *_Nullable error))completion;
 
-@interface SKYFetchResult
+// Generic RecordResult object for fetch, non-atomic save and delete
+@interface SKYRecordResult<ObjectType> : NSObject
 
-@property (nonatomic, readonly) SKYRecord *_Nullable record;
-@property (nonatomic, readonly) NSError *_Nullable error;
+@property (nonatomic, readonly) ObjectType value;
+@property (nonatomic, readonly) NSError* error;
 
 @end
 
 - (void)fetchRecordsWithType:(NSString *)recordType
                    recordIDs:(NSArray<NSString *> *)recordIDs
-                  completion:(void (^)(NSArray<SKYFetchResult*> *results,
+                  completion:(void (^)(NSArray<SKYRecordResult<SKYRecord*>*> *results,
                                        NSError *operationError))completion NS_REFINED_FOR_SWIFT;
 ```
 
@@ -230,16 +231,16 @@ typedef void (^SKYRecordSaveCompletion)(SKYRecord *record, NSError *error);
          completion:(void (^)(NSArray *savedRecords,
                               NSError *operationError))completion;
 
+// Generic RecordResult object for fetch, non-atomic save and delete
+@interface SKYRecordResult<ObjectType> : NSObject
 
-@interface SKYNonAtomicSaveResult
-
-@property (nonatomic, readonly) SKYRecord *_Nullable record;
-@property (nonatomic, readonly) NSError *_Nullable error;
+@property (nonatomic, readonly) ObjectType value;
+@property (nonatomic, readonly) NSError* error;
 
 @end
 
 - (void)saveRecordsNonAtomically:(NSArray<SKYRecord *> *)records
-                      completion:(void (^)(NSArray<SKYNonAtomicSaveResult*> *results,
+                      completion:(void (^)(NSArray<SKYRecordResult<SKYRecord*>*> *results,
                                            NSError *operationError))completion NS_REFINED_FOR_SWIFT;
 ```
 
@@ -363,22 +364,24 @@ saveNonAtomically(records: Record[]): Promise<NonAtomicSaveResult[]>;
                    completion:(void (^_Nullable)(NSArray *_Nullable deletedRecordIDs,
                                                  NSError *_Nullable error))completion;
 
-@interface SKYNonAtomicDeleteResult
+// Generic RecordResult object for fetch, non-atomic save and delete
+@interface SKYRecordResult<ObjectType> : NSObject
 
-@property (nonatomic, readonly) String *_Nullable recordID;
-@property (nonatomic, readonly) NSError *_Nullable error;
+@property (nonatomic, readonly) ObjectType value;
+@property (nonatomic, readonly) NSError* error;
 
 @end
 
+// results contain deleted record id
 - (void)deleteRecordsWithTypeNonAtomically:(NSString *)recordType
                                  recordIDs:(NSArray<NSString *> *)recordIDs
-                                completion:
-                            (void (^_Nullable)(NSArray<SKYNonAtomicDeleteResult*> *_Nullable results,
-                                               NSError *_Nullable error))completion NS_NS_REFINED_FOR_SWIFT;
+                                completion:(void (^_Nullable)(
+                                    NSArray<SKYRecordResult<NSString*>*> *_Nullable results,
+                                    NSError *_Nullable error))completion NS_NS_REFINED_FOR_SWIFT;
 ```
 
 ```swift
-enum RecordResult<T> {
+enum SKYRecordResult<T> {
     case success(T)
     case error(NSError)
 }

--- a/features/207-sdk-api-consistency/record-api.md
+++ b/features/207-sdk-api-consistency/record-api.md
@@ -146,6 +146,12 @@ skygear.getPublicDatabase().fetchRecordById("note", new String[]{"uuid1"}, new R
 ##### Old
 
 ```ts
+class QueryResult extends Array {
+  get overallCount() {
+    return this._overallCount;
+  }
+}
+
 getRecordByID(id: string): Promise<Record>;
 
 type cachedQueryCallback = (result: QueryResult, isCached: true) => void;
@@ -155,12 +161,22 @@ query(query: Query, cacheCallback: cachedQueryCallback): Promise<QueryResult>;
 ##### New
 
 ```ts
-type FetchResult = Map<string, Record>;
+type FetchResult = Record | Error;
 /**
  * The function reject if none is found
  */
-fetchRecordByID(type: string, id: string | string[]): Promise<FetchResult>;
+fetchRecordByID(type: string, id: string): Promise<Record>;
+/**
+ * The function resolve with individual record not found error.
+ * The function reject only for operational error e.g. network or server error.
+ */
+fetchRecordsByID(type: string, id: string[]): Promise<FetchResult[]>;
 
+class QueryResult extends Array {
+  get overallCount() {
+    return this._overallCount;
+  }
+}
 type cachedQueryCallback = (result: QueryResult, isCached: true) => void;
 query(query: Query, cacheCallback: cachedQueryCallback): Promise<QueryResult>;
 ```
@@ -271,16 +287,14 @@ save(records: Record | Record[], options: { atomic: boolean }): Promise<Record |
 ##### New
 
 ```ts
-/**
- * The function resolve with a single record when input is a single record.
- * The function resolve with array when input is array.
- */
-save(records: Record | Record[]): Promise<Record | Record[]>;
+saveRecord(record: Record): Promise<Record>;
+saveRecords(records: Record[]): Promise<Record[]>;
 
 type NonAtomicSaveResult = Record | Error;
 /**
- * The function resolve if at least one record is save sucessfully.
- * The function reject for any operational error or no record is saved.
+ * The function resolve with individual record cannot be saved error.
+ * The function reject only for operational error e.g. network or server error
+ *
  */
 saveNonAtomically(records: Record[]): Promise<NonAtomicSaveResult[]>;
 ```
@@ -405,16 +419,13 @@ del(records: Record | Record[] | QueryResult): Promise<DeleteResult | DeleteResu
 ##### New
 
 ```ts
-del(records: Record | Record[] | QueryResult): Promise<undefined>;
-// alias to
-// delete(records: Record | Record[] | QueryResult): Promise<undefined>;
+deleteRecord(record: Record): Promise<String>;
+deleteRecords(records: Record[] | QueryResult): Promise<String[]>;
 
-type NonAtomicDeleteResult = Error | undefined;
+type NonAtomicDeleteResult = String | Error;
 /**
- * The function resolve if at least one record is deleted sucessfully.
- * The function reject for any operational error or no record is deleted.
+ * The function resolve with individual record is not deleted error.
+ * The function reject only for operational error e.g. network or server error.
  */
-delNonAtomically(records: Record[] | QueryResult): Promise<NonAtomicDeleteResult[]>;
-// alias to
-// deleteNonAtomically(records: Record[] | QueryResult): Promise<NonAtomicDeleteResult[]>;
+deleteRecordsNonAtomically(records: Record[] | QueryResult): Promise<NonAtomicDeleteResult[]>;
 ```

--- a/features/207-sdk-api-consistency/record-api.md
+++ b/features/207-sdk-api-consistency/record-api.md
@@ -387,7 +387,7 @@ NS_SWIFT_NAME("__SKYRecordResult")
 @end
 
 // results contain deleted record id
-- (void)deleteRecordsWithTypeNonAtomically:(NSString *)recordType
+- (void)deleteRecordsNonAtomicallyWithType:(NSString *)recordType
                                  recordIDs:(NSArray<NSString *> *)recordIDs
                                 completion:(void (^_Nullable)(
                                     NSArray<SKYRecordResult<NSString*>*> *_Nullable results,
@@ -508,6 +508,6 @@ type NonAtomicDeleteResult = Record | Error;
  * The function resolve with individual record is not deleted error.
  * The function reject only for operational error e.g. network or server error.
  */
-deleteRecordsByIDNonAtomically(type: string, ids: Record[] | QueryResult): Promise<NonAtomicDeleteByIDResult[]>;
+deleteRecordsNonAtomicallyByID(type: string, ids: Record[] | QueryResult): Promise<NonAtomicDeleteByIDResult[]>;
 deleteRecordsNonAtomically(records: Record[] | QueryResult): Promise<NonAtomicDeleteResult[]>;
 ```


### PR DESCRIPTION
Update summary:

- For fetching single record, the callback is simple, success callback will be called if record is found, otherwise fail callback will be called
- For fetching multiple records, save and delete records non-atomically, fail callback will be called only when there are operational error. For any individual errors, it will return in the success callback with the result object. The result representation in 3 platforms will be 
    - JS, Union type result object
        - `type FetchResult = Record | Error`
        - `type NonAtomicSaveResult = Record | Error`
        - `type NonAtomicDeleteResult = String | Error`
    - iOS Objective C, individual result object with record and error
        - `SKYFetchResult`, `SKYNonAtomicSaveResult` and `SKYNonAtomicDeleteResult`
    - Android Java and Koltin
        - Generic `RecordResult<T>` that T will be Record in fetch and save, T will be String in delete
- In Android, it is strange that handler always return array even we use single record save and delet api. We updated to use generic in `RecordFetchResponseHandler<T>`, `RecordSaveResponseHandler<T>` and `RecordDeleteResponseHandler<T>` to handle this problem.
- In JS, save and delete api, if user save with array that contain 1 record. We resolved with single record instead of array with 1 record. To solve this, we separate single and multiple records function, so that we can have api input output symmetric.
- Support both delete records by ids or by records in all SDKs