### PR TITLE
Separate repo for cloud SDK

### DIFF
--- a/features/282-next-repo-re-organization/plan.md
+++ b/features/282-next-repo-re-organization/plan.md
@@ -12,6 +12,8 @@ The top level is the git repository.
 - skygear-SDK-JS
 - skygear-SDK-iOS
 - skygear-SDK-Android
+- skygear-cloud-node
+    - cloud sdk for auth hooks and cloud functions
 - skygear-controller
     - skycli and portal backend
     - manage cluster users


### PR DESCRIPTION
connect #282

I suggest to have separate repo for cloud SDK. Cloud SDK should also deploy as separate npm package.