### PR TITLE
Update user auth in skycli

### DIFF
--- a/features/270-next-skycli/api.md
+++ b/features/270-next-skycli/api.md
@@ -46,8 +46,8 @@ skycli [group] [verb/action] [parameters]
     - [skycli config set-app [APP_NAME]](commands.md#skycli-config-set-app)
     - [skycli config set-cluster-server [https://1.2.3.4]](commands.md#skycli-config-set-cluster-server)
 
-- skycli user (Admin only, cluster user management)
-    - [skycli user create](commands.md#skycli-user-create)
+- skycli user
+    - [skycli user signup](commands.md#skycli-user-signup)
     - [skycli user list](commands.md#skycli-user-list)
 
 #### Application commands

--- a/features/270-next-skycli/commands.md
+++ b/features/270-next-skycli/commands.md
@@ -53,11 +53,15 @@ admin.
 
 ## skycli user
 
-### skycli user create
+### skycli user signup
 
-`skycli user create`
+`skycli user signup`
 
-Cluster admin only. Create cluster user, need to provide email and password interactively.
+Signup cluster user, command will ask for password interactively.
+
+#### Flags
+
+- `--email=[EMAIL]` Provide user email.
 
 ### skycli user list
 

--- a/features/270-next-skycli/commands.md
+++ b/features/270-next-skycli/commands.md
@@ -2,15 +2,14 @@
 
 ### skycli auth login
 
-`skycli auth login [--email=EMAIL] [--admin-key=ADMIN_KEY]`
+`skycli auth login [--email=EMAIL]`
 
-Login as cluster admin or user, if no flags are provided. Will ask for email
+Login as cluster user, if no flags are provided. Will ask for email
 and password interactively.
 
 #### Flags
 
 - `--email=EMAIL` Login as cluster user, ask for password interactively.
-- `--admin-key=ADMIN_KEY` Login as cluster admin, no password is needed.
 
 ### skycli auth logout
 
@@ -46,10 +45,16 @@ Change skycli current app context to `APP_NAME`
 
 ### skycli config set-cluster-server
 
-`skycli config set-cluster-server [CLUSTER_SERVER_URL]`
+`skycli config set-cluster-server --endpoint=[CLUSTER_SERVER_URL] --api-key=[API_KEY|MASTER_KEY]`
 
-Change current cluster controller server endpoint, it is provided by cluster
-admin.
+Change current cluster controller server endpoint and api key, it is provided
+by cluster admin. If cluster admin want to use admin only api, they should provide
+master key in the api key flag.
+
+#### Flags
+
+- `--endpoint=[CLUSTER_SERVER_URL]` Provide cluster controller endpoint url.
+- `--api-key=[API_KEY|MASTER_KEY]` Provide api key.
 
 ## skycli user
 
@@ -67,7 +72,7 @@ Signup cluster user, command will ask for password interactively.
 
 `skycli user list`
 
-Cluster admin only. List all cluster user.
+Master key only. List all cluster user.
 
 ## skycli app
 


### PR DESCRIPTION
We are going to use auth gear as the auth part of cluster controller, so we can gain advantage from auth gear features when we do the portal. So I update the cli spec as follow.

1. Change `user add` to `user signup` and accept public signup. 
1. Update `set-cluster-server` command and require api key.
1. Remove login with admin-key, if admin need to use skycli as admin. They should provide master key in the api-key flags in `set-cluster-server` command.

For point 1, if we do need to make signup private in future. We can use the signup hook to block the public signup.

The will deploy a single tenant auth gear with the controller to handle user signup request.